### PR TITLE
load saved palette choice at startup

### DIFF
--- a/gnuboy-go/main/main.c
+++ b/gnuboy-go/main/main.c
@@ -447,6 +447,7 @@ void app_main(void)
     odroid_gamepad_state lastJoysticState;
 
     scaling_enabled = odroid_settings_ScaleDisabled_get(ODROID_SCALE_DISABLE_GB) ? false : true;
+    pal_set(odroid_settings_GBPalette_get());
 
     odroid_input_gamepad_read(&lastJoysticState);
     


### PR DESCRIPTION
For me the saved color palette for gnuboy wasn't loaded on startup.
This commit should fix it. I hope the feature-quick-menu2 is the right branch to merge this into.